### PR TITLE
refactor: replace Class.create with functions

### DIFF
--- a/assets/js/braspag-auth3ds20-renderer.js
+++ b/assets/js/braspag-auth3ds20-renderer.js
@@ -1,4 +1,6 @@
-var BpmpiRenderer = Class.create();
+function BpmpiRenderer() {
+  this.initialize();
+}
 
 BpmpiRenderer.prototype = {
   initialize: function() {
@@ -40,3 +42,4 @@ BpmpiRenderer.prototype = {
     }
   },
 }
+

--- a/assets/js/braspag-auth3ds20.js
+++ b/assets/js/braspag-auth3ds20.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var BraspagAuth3ds20 = Class.create();
+function BraspagAuth3ds20() {
+  this.initialize();
+}
 
 BraspagAuth3ds20.prototype = {
 
@@ -314,4 +316,4 @@ BraspagAuth3ds20.prototype = {
   },
 };
 
-var bpmpi = new BraspagAuth3ds20;
+  var bpmpi = new BraspagAuth3ds20();

--- a/assets/js/braspag-authsop.js
+++ b/assets/js/braspag-authsop.js
@@ -1,4 +1,6 @@
-var Sop = Class.create();
+function Sop() {
+  this.initialize();
+}
 
 Sop.prototype = {
   initialize: async function () {

--- a/assets/js/braspag-verifycard.js
+++ b/assets/js/braspag-verifycard.js
@@ -1,4 +1,6 @@
-var VerifyCard = Class.create();
+function VerifyCard() {
+    this.initialize();
+}
 
 VerifyCard.prototype = {
     initialize: async function () {


### PR DESCRIPTION
## Summary
- replace Class.create with native constructors in SOP, 3DS, renderer, and verify card scripts
- keep global instances intact

## Testing
- `npm test` *(fails: Could not read package.json)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68960c70a6008324857b734e0ddf1b72