### PR TITLE
Update Braspag Pix settings with new options

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -128,3 +128,6 @@
 * Fixed a critical bug where the quantity of items in the cart was accessed as an object property instead of an array element.
 * Enabled the execution of anti-fraud analysis simultaneously with 3DS authentication.
 * Validation logic with handling of 3DS failure and error cases.
+
+= 2.3.5.42 - 2026-04-13 =
+* Add BancodoBrasil3 provider in pix payment method

--- a/includes/admin/braspag-pix-settings.php
+++ b/includes/admin/braspag-pix-settings.php
@@ -47,7 +47,7 @@ return apply_filters(
                 "Cielo30" => "Pix Gateway -> Cielo30",
                 "Cielo2" => "Pix Gateway -> Cielo2",
                 "Bradesco2" => "Pix Gateway -> Bradesco",
-                "BancodoBrasil3" => "Pix Gateway -> Bradesco",
+                "BancodoBrasil3" => "Pix Gateway -> Banco do Brasil",
                 "Simulado" => "Simulado"
             ]
         ),

--- a/includes/admin/braspag-pix-settings.php
+++ b/includes/admin/braspag-pix-settings.php
@@ -47,6 +47,7 @@ return apply_filters(
                 "Cielo30" => "Pix Gateway -> Cielo30",
                 "Cielo2" => "Pix Gateway -> Cielo2",
                 "Bradesco2" => "Pix Gateway -> Bradesco",
+                "BancodoBrasil3" => "Pix Gateway -> Bradesco",
                 "Simulado" => "Simulado"
             ]
         ),

--- a/wc-gateway-braspag.php
+++ b/wc-gateway-braspag.php
@@ -14,7 +14,7 @@
  * Author: Braspag
  * Author URI: https://braspag.com.br/
  *
- * Version: 2.3.5.41
+ * Version: 2.3.5.42
  * Requires at least: 5.3.2
  * Tested up to: 6.8.2
  * Requires PHP: 7.4
@@ -114,7 +114,7 @@ function wc_braspag_init()
 	 * Required minimums and constants
 	 */
 	global $wp_version;
-	$bp_version = '2.3.5.41';
+	$bp_version = '2.3.5.42';
 	$min_php_ver = '5.6.0';
 	$min_wc_ver = '4.0.0';
 	$min_wp_ver = '5.3.2';


### PR DESCRIPTION
Updates the WooCommerce Braspag Pix gateway settings to expose an additional Pix provider option in the admin configuration.

Changes:

- Adds a new available_type option entry for BancodoBrasil3 in Pix settings.