### PR TITLE
fix: update webhook validation

### DIFF
--- a/assets/js/blocks/braspag-pix.js
+++ b/assets/js/blocks/braspag-pix.js
@@ -6,6 +6,7 @@
     const { createElement: el, Fragment } = wp.element;
 
     const settings = getSetting('braspag_pix_data', {});
+    const methodTitle = settings.title ? 'Braspag - ' + settings.title : __('Braspag - Pix', 'woocommerce-braspag');
 
     const Content = () =>
         el(
@@ -27,15 +28,15 @@
                         color: '#1e40af'
                     }
                 },
-                el('strong', null, '📄 Documento obrigatório: '),
+                el('strong', null, __('Documento obrigatório: ', 'woocommerce-braspag')),
                 'Certifique-se de preencher seu CPF ou CNPJ nos dados de cobrança para utilizar o PIX.'
             )
         );
 
     registerPaymentMethod({
         name: 'braspag_pix',
-        label: 'Braspag - ' + settings.title || __('Braspag - Pix', 'woocommerce-braspag'),
-        ariaLabel: 'Braspag - ' + settings.title || __('Braspag - Pix', 'woocommerce-braspag'),
+        label: methodTitle,
+        ariaLabel: methodTitle,
         canMakePayment: () => true,
         content: el(Content, null),
         edit: el(Content, null),

--- a/includes/class-wc-braspag-helper.php
+++ b/includes/class-wc-braspag-helper.php
@@ -118,7 +118,48 @@ class WC_Braspag_Helper
 			return false;
 		}
 
-		$order_id = $wpdb->get_var($wpdb->prepare("SELECT DISTINCT ID FROM $wpdb->posts as posts LEFT JOIN $wpdb->postmeta as meta ON posts.ID = meta.post_id WHERE meta.meta_value = %s AND meta.meta_key = %s", $charge_id, '_transaction_id'));
+		if (function_exists('wc_get_orders')) {
+			$orders = wc_get_orders(array(
+				'limit' => 1,
+				'type' => 'shop_order',
+				'meta_key' => '_braspag_pix_payment_id',
+				'meta_value' => $charge_id,
+			));
+
+			if (!empty($orders) && is_object($orders[0]) && method_exists($orders[0], 'get_id')) {
+				return $orders[0];
+			}
+
+			$orders = wc_get_orders(array(
+				'limit' => 1,
+				'type' => 'shop_order',
+				'transaction_id' => $charge_id,
+			));
+
+			if (!empty($orders) && is_object($orders[0]) && method_exists($orders[0], 'get_id')) {
+				return $orders[0];
+			}
+		}
+
+		$order_id = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT DISTINCT ID FROM $wpdb->posts as posts LEFT JOIN $wpdb->postmeta as meta ON posts.ID = meta.post_id WHERE meta.meta_value = %s AND meta.meta_key = %s LIMIT 1",
+				$charge_id,
+				'_braspag_pix_payment_id'
+			)
+		);
+
+		if (!empty($order_id)) {
+			return wc_get_order($order_id);
+		}
+
+		$order_id = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT post_id FROM $wpdb->postmeta WHERE meta_key = %s AND meta_value = %s LIMIT 1",
+				'_transaction_id',
+				$charge_id
+			)
+		);
 
 		if (!empty($order_id)) {
 			return wc_get_order($order_id);

--- a/includes/class-wc-braspag-webhook-handler.php
+++ b/includes/class-wc-braspag-webhook-handler.php
@@ -31,11 +31,12 @@ class WC_Braspag_Webhook_Handler extends WC_Braspag_Payment_Gateway
             return;
         }
 
-        $request_body = json_decode(file_get_contents('php://input'), true);
+        $raw_body = file_get_contents('php://input');
+        $request_body = json_decode($raw_body, true);
         $request_headers = array_change_key_case($this->get_request_headers(), CASE_UPPER);
 
         try {
-            if (!$this->is_valid_request($request_headers, $request_body)) {
+            if (!$this->is_valid_request($request_headers, $request_body, $raw_body)) {
                 throw new WC_Braspag_Exception('Incoming webhook validation Error');
             }
 
@@ -58,17 +59,72 @@ class WC_Braspag_Webhook_Handler extends WC_Braspag_Payment_Gateway
      * @param null $request_body
      * @return bool
      */
-    public function is_valid_request($request_headers = null, $request_body = null)
+    public function is_valid_request($request_headers = null, $request_body = null, $raw_body = '')
     {
-        if (null === $request_headers || null === $request_body || !$request_body) {
+        if (null === $request_headers || null === $request_body || '' === $raw_body) {
             return false;
         }
 
-        if (!isset($request_body['PaymentId']) || !isset($request_body['ChangeType'])) {
+        if (JSON_ERROR_NONE !== json_last_error() || !is_array($request_body)) {
             return false;
         }
 
-        return true;
+        if (empty($request_body['PaymentId']) || empty($request_body['ChangeType'])) {
+            return false;
+        }
+
+        $change_type = (string) $request_body['ChangeType'];
+
+        if (!in_array($change_type, array('1', '2', '3', '4', '5', '6', '7', '8'), true)) {
+            return false;
+        }
+
+        if (!$this->is_valid_signature($request_headers, $raw_body)) {
+            return false;
+        }
+
+        return (bool) apply_filters('wc_braspag_validate_webhook_request', true, $request_headers, $request_body, $raw_body);
+    }
+
+    /**
+     * @param array $request_headers
+     * @param string $raw_body
+     * @return bool
+     */
+    private function is_valid_signature($request_headers, $raw_body)
+    {
+        $secret = $this->get_webhook_secret();
+
+        if ('' === $secret) {
+            return true;
+        }
+
+        $signature_header = strtoupper((string) apply_filters('wc_braspag_webhook_signature_header', 'X-BRASPAG-SIGNATURE'));
+        $signature = isset($request_headers[$signature_header]) ? (string) $request_headers[$signature_header] : '';
+
+        if ('' === $signature) {
+            return false;
+        }
+
+        $expected = hash_hmac('sha256', $raw_body, $secret);
+
+        if (hash_equals($expected, $signature)) {
+            return true;
+        }
+
+        $expected_base64 = base64_encode(hex2bin($expected));
+
+        return hash_equals($expected_base64, $signature);
+    }
+
+    /**
+     * @return string
+     */
+    private function get_webhook_secret()
+    {
+        $settings = get_option('woocommerce_braspag_settings', array());
+
+        return isset($settings['webhook_secret']) ? trim((string) $settings['webhook_secret']) : '';
     }
 
     /**
@@ -98,11 +154,12 @@ class WC_Braspag_Webhook_Handler extends WC_Braspag_Payment_Gateway
      */
     public function process_webhook($request_body)
     {
-        $changeType = $request_body['ChangeType'];
+        $changeType = (string) $request_body['ChangeType'];
+        $payment_id = sanitize_text_field($request_body['PaymentId']);
 
         switch ($changeType) {
             case '1':
-                $this->process_change_type_status_update($request_body['PaymentId']);
+            $this->process_change_type_status_update($payment_id);
                 break;
 
             case '2':

--- a/includes/payment-methods/class-wc-gateway-braspag-pix.php
+++ b/includes/payment-methods/class-wc-gateway-braspag-pix.php
@@ -121,6 +121,8 @@ class WC_Gateway_Braspag_Pix extends WC_Gateway_Braspag
      */
     public function process_payment($order_id, $retry = true, $previous_error = false, $use_order_source = false)
     {
+        $order = null;
+
         try {
             do_action('wc_gateway_braspag_pagador_pix_process_payment_before', $order_id, $retry, $previous_error, $use_order_source);
 
@@ -174,10 +176,15 @@ class WC_Gateway_Braspag_Pix extends WC_Gateway_Braspag
             wc_add_notice($e->getLocalizedMessage(), 'error');
             WC_Braspag_Logger::log('Error: ' . $e->getMessage());
 
-            do_action('wc_gateway_braspag_pagador_process_payment_error', $e, $order);
+            if (is_object($order) && method_exists($order, 'get_transaction_id')) {
+                do_action('wc_gateway_braspag_pagador_process_payment_error', $e, $order);
 
-            /* translators: error message */
-            $order->update_status('failed');
+                if ($order->get_transaction_id()) {
+                    $order->update_status('failed');
+                } else {
+                    $order->add_order_note($e->getLocalizedMessage());
+                }
+            }
 
             return array(
                 'result' => 'fail',
@@ -380,10 +387,15 @@ class WC_Gateway_Braspag_Pix extends WC_Gateway_Braspag
 
         $_braspag_pix_expiration_date = $order->get_meta('_braspag_pix_expiration_date');
         $_braspag_pix_received_date = $order->get_meta('_braspag_pix_received_date');
-        $explodeExpirationDate = explode("-", $_braspag_pix_expiration_date);
-        $startTime = strtotime($_braspag_pix_received_date);
-        $endTime = strtotime("+{$explodeExpirationDate[0]} seconds", $startTime);
-        $expirationDate = date('H:i', $endTime);
+        $explodeExpirationDate = explode("-", (string) $_braspag_pix_expiration_date);
+        $expirationSeconds = isset($explodeExpirationDate[0]) ? absint($explodeExpirationDate[0]) : 0;
+        $startTime = strtotime((string) $_braspag_pix_received_date);
+        $endTime = $startTime && $expirationSeconds ? strtotime("+{$expirationSeconds} seconds", $startTime) : false;
+        $expirationDate = $endTime ? date_i18n('H:i', $endTime) : '';
+        $imageQrcode = preg_replace('/[^A-Za-z0-9+\/=]/', '', (string) $order->get_meta('_braspag_pix_qr_code_image'));
+        $digitableLine = (string) $order->get_meta('_braspag_pix_digitable_line');
+        $copyButtonId = 'braspag-pix-copy-' . $order->get_id();
+        $digitableFieldId = 'braspag-pix-line-' . $order->get_id();
 
         do_action('wc_gateway_braspag_pagador_pix_display_order_data_before', $order);
         $swf_url = esc_url(plugins_url('assets/images/pix.webp', dirname(dirname(__FILE__))));
@@ -399,7 +411,7 @@ class WC_Gateway_Braspag_Pix extends WC_Gateway_Braspag
                                                     <td class="woocommerce-table__product-total product-total text-center validade-pix" colspan="2">
                                                         <p class="stopwatch">
                                                             <img class="image-time" src="<?php echo $timer_url; ?>" alt="timer">
-                                                             Validade do código Pix até às: <strong><?php echo $expirationDate; ?></strong>
+                                                             Validade do código Pix até às: <strong><?php echo esc_html($expirationDate); ?></strong>
                                                         </p>
                                                     </td>
                                                 </tr>
@@ -410,16 +422,17 @@ class WC_Gateway_Braspag_Pix extends WC_Gateway_Braspag
                                                             Para pagar no banco on-line ou aplicativo do seu banco,
                                                             <strong>Escanei o QR Code ou copie o código Pix:</strong>
                                                         </p>
-                                                        <?php $imageQrcode = $order->get_meta('_braspag_pix_qr_code_image'); ?>
-                                                        <img alt="QR-Code PIX" src="data:image/png;base64,<?php echo $imageQrcode; ?>" />
+                                                        <?php if ($imageQrcode) : ?>
+                                                        <img alt="QR-Code PIX" src="data:image/png;base64,<?php echo esc_attr($imageQrcode); ?>" />
+                                                        <?php endif; ?>
                                                     </td>
                                                 </tr>
 
                                                 <tr class="woocommerce-table__line-item order_item">
                                                     <td class="woocommerce-table__product-total product-total text-center">
-                                                        <textarea disabled id="linha-digitavel"><?php echo $order->get_meta('_braspag_pix_digitable_line'); ?></textarea>
+                                                        <textarea disabled id="<?php echo esc_attr($digitableFieldId); ?>"><?php echo esc_textarea($digitableLine); ?></textarea>
                                                         <br>
-                                                        <button onclick="copiarTexto()"><b>Copiar código Pix</b></button>
+                                                        <button type="button" id="<?php echo esc_attr($copyButtonId); ?>"><b>Copiar código Pix</b></button>
                                                     </td>
                                                 </tr>
 
@@ -440,16 +453,22 @@ class WC_Gateway_Braspag_Pix extends WC_Gateway_Braspag
                                             </tbody>
                                         </table>
                                         <script>
-                                            function copiarTexto() {
-                                                let textoCopiado = document.getElementById("linha-digitavel");
+                                            (function() {
+                                                var copyButton = document.getElementById(<?php echo wp_json_encode($copyButtonId); ?>);
+                                                var digitableField = document.getElementById(<?php echo wp_json_encode($digitableFieldId); ?>);
 
-                                                textoCopiado.select();
-                                                textoCopiado.setSelectionRange(0, 99999);
+                                                if (!copyButton || !digitableField || !navigator.clipboard) {
+                                                    return;
+                                                }
 
-                                                navigator.clipboard.writeText(textoCopiado.value);
-
-                                                console.log("O texto é: " + textoCopiado.value);
-                                            }
+                                                copyButton.addEventListener('click', function() {
+                                                    digitableField.removeAttribute('disabled');
+                                                    digitableField.select();
+                                                    digitableField.setSelectionRange(0, 99999);
+                                                    navigator.clipboard.writeText(digitableField.value);
+                                                    digitableField.setAttribute('disabled', 'disabled');
+                                                });
+                                            }());
                                         </script>
                                         <?php
 


### PR DESCRIPTION
Updates webhook validation and improves Pix UX/security handling across checkout and order details.

Changes:

Adds stricter webhook payload validation and optional HMAC signature verification using the raw request body.
Improves Pix order details rendering by sanitizing/escaping output and making the “copy code” behavior safer and per-order.
Updates order lookup by charge/payment id to prefer WooCommerce order queries before falling back to direct SQL.