### PR TITLE
Fix: remove headers for validations in webhook

### DIFF
--- a/includes/admin/braspag-settings.php
+++ b/includes/admin/braspag-settings.php
@@ -218,20 +218,6 @@ return apply_filters(
             /* translators: post_notification URL */
             'description' => $this->display_admin_settings_webhook_description(),
         ),
-        'webhook_header_key' => array(
-            'title' => __('Webhook Header Key', 'woocommerce-braspag'),
-            'type' => 'text',
-            'description' => __('Header name configured in Braspag panel (KEY). Example: X-BRASPAG-SIGNATURE', 'woocommerce-braspag'),
-            'default' => 'X-BRASPAG-SIGNATURE',
-            'desc_tip' => true,
-        ),
-        'webhook_secret' => array(
-            'title' => __('Webhook Header Value', 'woocommerce-braspag'),
-            'type' => 'password',
-            'description' => __('Static value configured in Braspag panel (VALUE). The webhook will only be accepted if this header is present.', 'woocommerce-braspag'),
-            'default' => '',
-            'desc_tip' => true,
-        ),
         'antifraud' => array(
             'title' => "<hr>" . __('Anti Fraud', 'woocommerce-braspag'),
             'type' => 'title',


### PR DESCRIPTION
This PR removes the admin settings fields used to configure webhook header-based validation for Braspag post notifications. In the current codebase, those settings are tied to webhook request signature checks, so removing them changes how webhook authenticity can be enforced.

Changes:

Removed webhook_header_key setting from the Braspag settings screen.
Removed webhook_secret setting from the Braspag settings screen.